### PR TITLE
FSUI: Fix cheevo progress % text centering

### DIFF
--- a/pcsx2/Achievements.cpp
+++ b/pcsx2/Achievements.cpp
@@ -2266,7 +2266,9 @@ void Achievements::DrawAchievementsWindow()
 					ImGui::GetColorU32(ImGuiFullscreen::UISecondaryColor));
 
 				text.format("{}%", static_cast<int>(std::round(fraction * 100.0f)));
+				ImGui::PushFont(g_medium_font);
 				text_size = ImGui::CalcTextSize(text.c_str(), text.end_ptr());
+				ImGui::PopFont();
 				const ImVec2 text_pos(progress_bb.Min.x + ((progress_bb.Max.x - progress_bb.Min.x) / 2.0f) - (text_size.x / 2.0f),
 					progress_bb.Min.y + ((progress_bb.Max.y - progress_bb.Min.y) / 2.0f) - (text_size.y / 2.0f));
 				dl->AddText(g_medium_font, g_medium_font->FontSize, text_pos, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryTextColor),


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
Push g_medium_font before CalcTextSize is called for the achievement unlock progress text.

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
This fixes the issue where, depending on the window size/aspect ratio, the vertical centering would be off.

![image](https://github.com/user-attachments/assets/c4b0eef6-7a39-4ac2-bded-090f69ed8836)

Noticed this on a 1440p monitor with a maximized window.


### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
I've tested by manually resizing the window.

#### Before
![image](https://github.com/user-attachments/assets/ddcee17e-8d37-4112-844c-9684fffd41ce)
#### After
![image](https://github.com/user-attachments/assets/d81b50c8-9f0d-4f80-b48a-85aa1c140557)
